### PR TITLE
renderite: Move definition of shared data, automatically determine default output path in generator

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -229,7 +229,7 @@ pub fn build(b: *std.Build) void {
     };
 
     const renderite_mod = create_renderite_mod: {
-        const renderite_root = b.path("renderite/shared/");
+        const renderite_root = b.path("renderite/");
 
         const renderite_mod = b.createModule(.{
             .root_source_file = renderite_root.path(b, "renderite.zig"),

--- a/client/main.zig
+++ b/client/main.zig
@@ -3,7 +3,7 @@ const builtin = @import("builtin");
 
 const build_options = @import("options").build_options;
 const gpu = @import("gpu");
-const renderite = @import("renderite");
+const renderite = @import("renderite").Shared;
 const sdl3 = @import("sdl3");
 const xr = @import("xr");
 const zinterprocess = @import("zinterprocess");

--- a/renderite/generator/RenderiteGenerator/Generator.cs
+++ b/renderite/generator/RenderiteGenerator/Generator.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Diagnostics;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 namespace RenderiteGenerator;
@@ -12,6 +13,8 @@ public class Generator : IDisposable
 
     public Generator(GeneratorOptions options)
     {
+        options.OutputZigFile ??= DetermineDefaultOutputPath();
+        
         if(File.Exists(options.OutputZigFile))
             File.Delete(options.OutputZigFile);
         
@@ -19,6 +22,26 @@ public class Generator : IDisposable
         this._fileStream = File.OpenWrite(options.OutputZigFile);
         this._writer = new StreamWriter(this._fileStream);
         this._verbose = options.Verbose;
+    }
+
+    private static string DetermineDefaultOutputPath()
+    {
+        Process process = Process.Start(new ProcessStartInfo()
+        {
+            FileName = "git",
+            Arguments = "rev-parse --show-toplevel",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+        })!;
+        process.WaitForExit();
+        if (process.ExitCode != 0)
+            throw new Exception("Git exited with exit code " + process.ExitCode);
+
+        string? output = process.StandardOutput.ReadLine();
+        if (output == null)
+            throw new Exception("Git returned no output");
+        
+        return Path.Combine(output, "renderite", "shared.zig");
     }
 
     public void Run()
@@ -32,7 +55,7 @@ public class Generator : IDisposable
         }
     }
 
-    public void WriteEnum(Type t)
+    private void WriteEnum(Type t)
     {
         if(this._verbose)
             Console.WriteLine($"Writing enum {t.FullName}");

--- a/renderite/generator/RenderiteGenerator/GeneratorOptions.cs
+++ b/renderite/generator/RenderiteGenerator/GeneratorOptions.cs
@@ -10,6 +10,6 @@ public class GeneratorOptions
     [Option('i', "assembly-path", Required = true, HelpText = "The absolute path to the Renderite.Shared.dll file.")]
     public string AssemblyPath { get; set; } = null!;
 
-    [Option('o', "output-zig-file", Required = false, Default = "renderite.zig", HelpText = "The destination .zig file to generate.")]
-    public string OutputZigFile { get; set; } = "renderite.zig";
+    [Option('o', "output-zig-file", Required = false, Default = null, HelpText = "The destination .zig file to generate.")]
+    public string? OutputZigFile { get; set; } = null;
 }

--- a/renderite/generator/RenderiteGenerator/RenderiteGenerator.sln.DotSettings
+++ b/renderite/generator/RenderiteGenerator/RenderiteGenerator.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=renderite/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/renderite/renderite.zig
+++ b/renderite/renderite.zig
@@ -1,0 +1,1 @@
+pub const Shared = @import("shared.zig");

--- a/renderite/shared.zig
+++ b/renderite/shared.zig
@@ -6,6 +6,35 @@ pub const ColorProfile = enum(i32) {
 	sRGBAlpha = 2,
 };
 
+pub const GaussianVectorFormat = enum(i32) {
+	Float32 = 0,
+	Norm16 = 1,
+	Norm11 = 2,
+	Norm6 = 3,
+};
+
+pub const GaussianRotationFormat = enum(i32) {
+	PackedNorm10 = 0,
+};
+
+pub const GaussianColorFormat = enum(i32) {
+	Float32x4 = 0,
+	Float16x4 = 1,
+	Norm8x4 = 2,
+	BC7 = 3,
+};
+
+pub const GaussianSHFormat = enum(i32) {
+	Float16 = 0,
+	Norm11 = 1,
+	Norm6 = 2,
+	Cluster64k = 3,
+	Cluster32k = 4,
+	Cluster16k = 5,
+	Cluster8k = 6,
+	Cluster4k = 7,
+};
+
 pub const BlendshapeDataFlags = enum(i32) {
 	NONE = 0,
 	Positions = 1,


### PR DESCRIPTION
I've moved the `shared/renderite.zig` to `shared.zig` and introduced a new root module to allow for expansion of that module, since I want to put the messaging system in the `renderite` module.

I also improved the usability of the generator by making the default path be automatically determined via invoking the git CLI to find the repository root.

This also updates the generated definitions to Resonite 2025.8.2.1133.