### PR TITLE
perf: Track and report performance statistics

### DIFF
--- a/client/App.zig
+++ b/client/App.zig
@@ -19,6 +19,7 @@ const Input = @import("Input.zig");
 const RenderSpace = @import("RenderSpace.zig");
 const Texture = @import("Texture.zig");
 const ImGuiManager = @import("gui/ImGuiManager.zig");
+const PerformanceMonitor = @import("PerformanceMonitor.zig");
 
 pub const MessagingHost = renderite.MessagingHost(*App);
 const log = std.log.scoped(.app);
@@ -151,6 +152,7 @@ const GameData = struct {
     render_spaces: std.AutoArrayHashMapUnmanaged(RenderSpace.Id, RenderSpace),
 
     input: Input,
+    perf: PerformanceMonitor,
 
     pub fn deinit(self: *GameData, gpa: std.mem.Allocator) void {
         if (self.engine_thread) |engine_thread| {
@@ -397,6 +399,7 @@ pub fn init(gpa: std.mem.Allocator, settings: InitSettings) !*App {
             .to_engine_envelope_pool = .init(gpa),
             .displays = .empty,
             .input = input,
+            .perf = PerformanceMonitor.init(),
             .render_spaces = .empty,
             .render_spaces_lock = .{},
         };
@@ -918,6 +921,8 @@ pub fn frameLoop(self: *App) !void {
 
     while (self.game.run_loop) {
         tracy.frameMark();
+        self.game.perf.frame();
+        defer self.game.perf.endFrame();
 
         {
             const trace = tracy.traceNamed(@src(), "Poll SDL events");
@@ -1061,7 +1066,7 @@ pub fn frameLoop(self: *App) !void {
                                 .resolutionSettingsApplied = false,
                             },
                         },
-                        .performance = null,
+                        .performance = self.game.perf.state,
                         .renderedReflectionProbes = &.{},
                     },
                 }, std.time.ns_per_s);

--- a/client/App.zig
+++ b/client/App.zig
@@ -921,8 +921,8 @@ pub fn frameLoop(self: *App) !void {
 
     while (self.game.run_loop) {
         tracy.frameMark();
-        self.game.perf.frame();
-        defer self.game.perf.endFrame();
+        self.game.perf.beginRenderFrame();
+        defer self.game.perf.endRenderFrame();
 
         {
             const trace = tracy.traceNamed(@src(), "Poll SDL events");

--- a/client/App.zig
+++ b/client/App.zig
@@ -368,6 +368,7 @@ pub fn init(gpa: std.mem.Allocator, settings: InitSettings) !*App {
             .assets_open = true,
             .loadstate_open = true,
             .demo_open = true,
+            .performance_open = true,
             .temporary_graphics_bindings = .empty,
         };
     };

--- a/client/PerformanceMonitor.zig
+++ b/client/PerformanceMonitor.zig
@@ -1,0 +1,74 @@
+const std = @import("std");
+const renderite = @import("renderite");
+
+const log = std.log.scoped(.perf);
+
+const PerformanceMonitor = @This();
+
+// const F = f32; // too little to fit timestamp
+const F = f64;
+// const F = f128; // no effect
+
+state: renderite.Shared.PerformanceState,
+last_update: F,
+last_frame: F,
+counter: u32,
+
+pub fn init() PerformanceMonitor {
+    return .{
+        .state = .{
+            .fps = 0,
+            .immediateFPS = 0,
+            .renderTime = 0,
+            .externalUpdateTime = 0,
+            .frameBeginToSubmitTime = 0,
+            .frameProcessedToNextBeginTime = 0,
+            .integrationProcessingTime = 0,
+            .extraParticleProcessingTime = 0,
+            .processedAssetIntegratorTasks = 0,
+            .integrationHighPriorityTasks = 0,
+            .integrationTasks = 0,
+            .integrationRenderTasks = 0,
+            .integrationParticleTasks = 0,
+            .processingHandleWaits = 0,
+            .frameUpdateHandleTime = 0,
+            .renderedCameras = 0,
+            .renderedCameraPortals = 0,
+            .updatedTextures = 0,
+            .textureSliceUploads = 0,
+        },
+        .counter = 0,
+        .last_update = timestamp(),
+        .last_frame = timestamp(),
+    };
+}
+
+const TimeBase = 1000.0;
+const TimeBaseInverse = 1.0 / TimeBase;
+
+fn timestamp() F {
+    return @floatFromInt(std.time.milliTimestamp());
+}
+
+pub fn frame(self: *PerformanceMonitor) void {
+    const now = timestamp();
+
+    self.counter += 1;
+    self.last_frame = now;
+
+    const total_milliseconds = now - self.last_update;
+    if (total_milliseconds >= (TimeBase / 2.0)) {
+        self.state.fps = @floatCast(@as(F, @floatFromInt(self.counter)) / (total_milliseconds * (TimeBaseInverse)));
+        self.counter = 0;
+        self.last_update = now;
+
+        log.debug("FPS state: {any}", .{self});
+    }
+}
+
+pub fn endFrame(self: *PerformanceMonitor) void {
+    const now = timestamp();
+    const draw = now - self.last_frame;
+    self.state.renderTime = @floatCast(draw / TimeBase);
+    self.state.immediateFPS = @floatCast(TimeBase / draw);
+}

--- a/client/PerformanceMonitor.zig
+++ b/client/PerformanceMonitor.zig
@@ -39,7 +39,7 @@ pub fn init() PerformanceMonitor {
     };
 }
 
-const time_base = @as(comptime_float, @floatFromInt(std.time.ns_per_s));
+const time_base: comptime_float = std.time.ns_per_s;
 const time_base_inverse = 1.0 / time_base;
 
 fn timestamp() i128 {
@@ -57,8 +57,6 @@ pub fn beginRenderFrame(self: *PerformanceMonitor) void {
         self.state.fps = @as(f32, @floatFromInt(self.counter)) / (@as(f32, @floatFromInt(total)) * (time_base_inverse));
         self.counter = 0;
         self.last_update = now;
-
-        log.debug("FPS state: {any}", .{self});
     }
 }
 

--- a/client/PerformanceMonitor.zig
+++ b/client/PerformanceMonitor.zig
@@ -5,13 +5,9 @@ const log = std.log.scoped(.perf);
 
 const PerformanceMonitor = @This();
 
-// const F = f32; // too little to fit timestamp
-const F = f64;
-// const F = f128; // no effect
-
 state: renderite.Shared.PerformanceState,
-last_update: F,
-last_frame: F,
+last_update: i128,
+last_frame: i128,
 counter: u32,
 
 pub fn init() PerformanceMonitor {
@@ -43,22 +39,22 @@ pub fn init() PerformanceMonitor {
     };
 }
 
-const TimeBase = 1000.0;
-const TimeBaseInverse = 1.0 / TimeBase;
+const time_base = @as(comptime_float, @floatFromInt(std.time.ns_per_s));
+const time_base_inverse = 1.0 / time_base;
 
-fn timestamp() F {
-    return @floatFromInt(std.time.milliTimestamp());
+fn timestamp() i128 {
+    return std.time.nanoTimestamp();
 }
 
-pub fn frame(self: *PerformanceMonitor) void {
+pub fn beginRenderFrame(self: *PerformanceMonitor) void {
     const now = timestamp();
 
     self.counter += 1;
     self.last_frame = now;
 
-    const total_milliseconds = now - self.last_update;
-    if (total_milliseconds >= (TimeBase / 2.0)) {
-        self.state.fps = @floatCast(@as(F, @floatFromInt(self.counter)) / (total_milliseconds * (TimeBaseInverse)));
+    const total = now - self.last_update;
+    if (total >= (time_base / 2.0)) {
+        self.state.fps = @as(f32, @floatFromInt(self.counter)) / (@as(f32, @floatFromInt(total)) * (time_base_inverse));
         self.counter = 0;
         self.last_update = now;
 
@@ -66,9 +62,9 @@ pub fn frame(self: *PerformanceMonitor) void {
     }
 }
 
-pub fn endFrame(self: *PerformanceMonitor) void {
+pub fn endRenderFrame(self: *PerformanceMonitor) void {
     const now = timestamp();
-    const draw = now - self.last_frame;
-    self.state.renderTime = @floatCast(draw / TimeBase);
-    self.state.immediateFPS = @floatCast(TimeBase / draw);
+    const draw: f32 = @floatFromInt(now - self.last_frame);
+    self.state.renderTime = draw / time_base;
+    self.state.immediateFPS = time_base / draw;
 }

--- a/client/gui/ImGuiManager.zig
+++ b/client/gui/ImGuiManager.zig
@@ -11,6 +11,7 @@ context: imgui.Context,
 
 demo_open: bool,
 assets_open: bool,
+performance_open: bool,
 loadstate_open: bool,
 
 temporary_graphics_bindings: std.ArrayListUnmanaged(gpu.TextureSamplerBinding),
@@ -60,6 +61,14 @@ pub fn start(self: *ImGuiManager) !void {
             if (imgui.collapsingHeader("Render Spaces", 0)) {
                 self.fillRenderSpaces();
             }
+        }
+    }
+
+    {
+        const performance_render = imgui.begin("Performance", &self.performance_open, 0);
+        defer imgui.end();
+        if (performance_render) {
+            self.fillPerformance();
         }
     }
 
@@ -252,4 +261,11 @@ fn fillRenderSpaces(self: *ImGuiManager) void {
             imgui.c.igText("View transform not overridden.");
         }
     }
+}
+
+fn fillPerformance(self: *ImGuiManager) void {
+    const perf = self.app.game.perf.state;
+    // TODO: truncate floats so they are prettier
+    imgui.c.igText("FPS: %f", perf.fps);
+    imgui.c.igText("Render time: %fms", perf.renderTime);
 }


### PR DESCRIPTION
This partially implements the FPS monitoring requested by the engine each frame. Closes #73.

I left some timing/precision-related junk in while trying to test some stuff but I decided to leave it in so it can easily be adjusted in the future if we need to.

In the future we'll want to make functions here that increment some counters that FE wants, e.g. when uploading textures, but I wanted this PR to be relatively small and easy to review.