### PR TITLE
renderite: Use pooling for shared memory views

### DIFF
--- a/client/App.zig
+++ b/client/App.zig
@@ -6,20 +6,23 @@ const gpu = @import("gpu");
 const imgui = @import("imgui");
 const mailbox = @import("mailbox");
 const math = @import("math");
-const renderite = @import("renderite");
-const SharedMemoryAccessor = renderite.SharedMemoryAccessor;
-const InitSettings = renderite.InitSettings;
 const sdl3 = @import("sdl3");
 const tracy = @import("tracy");
 const xr_t = @import("xr");
 
 const Assets = @import("Assets.zig");
-const graphics = @import("graphics.zig");
 const ImGuiManager = @import("gui/ImGuiManager.zig");
 const Input = @import("Input.zig");
 const PerformanceMonitor = @import("PerformanceMonitor.zig");
 const RenderSpace = @import("render_spaces/RenderSpace.zig");
 const Texture = @import("Texture.zig");
+
+const renderite = @import("renderite");
+const SharedMemoryAccessor = renderite.SharedMemoryAccessor;
+const InitSettings = renderite.InitSettings;
+const Pooling = renderite.Pooling;
+
+const graphics = @import("graphics.zig");
 
 pub const MessagingHost = renderite.MessagingHost(*App);
 const log = std.log.scoped(.app);

--- a/client/Mesh.zig
+++ b/client/Mesh.zig
@@ -97,7 +97,7 @@ pub fn setData(
 ) !void {
     // log.debug("Got mesh upload {any}", .{data_request});
 
-    const slice = try accessor.getOrCreate(u8, gpa, data_request.buffer) orelse {
+    const slice = try accessor.getOrCreate(u8, data_request.buffer) orelse {
         const vertex_attributes = try convertVertexAttributes(gpa, data_request.vertexAttributes);
         errdefer gpa.free(vertex_attributes);
 

--- a/client/Mesh.zig
+++ b/client/Mesh.zig
@@ -116,7 +116,7 @@ pub fn setData(
 
         return;
     };
-    defer slice.release(accessor);
+    defer accessor.release(gpa, slice);
 
     const data = slice.data;
 

--- a/client/Texture.zig
+++ b/client/Texture.zig
@@ -423,7 +423,7 @@ pub fn setData2d(
     data: renderite.Shared.SetTexture2DData,
     accessor: *renderite.SharedMemoryAccessor,
 ) !void {
-    const data_slice = try accessor.getOrCreate(u8, gpa, data.data) orelse return error.MissingBuffer;
+    const data_slice = try accessor.getOrCreate(u8, data.data) orelse return error.MissingBuffer;
     defer accessor.release(gpa, data_slice);
 
     // std.debug.print("Texture2D upload details: {any}\n", .{data});
@@ -553,7 +553,7 @@ pub fn setData3d(
     data: renderite.Shared.SetTexture3DData,
     accessor: *renderite.SharedMemoryAccessor,
 ) !void {
-    const data_slice = try accessor.getOrCreate(u8, gpa, data.data) orelse return error.MissingBuffer;
+    const data_slice = try accessor.getOrCreate(u8, data.data) orelse return error.MissingBuffer;
     defer accessor.release(gpa, data_slice);
 
     // std.debug.print("Texture3D upload details: {any}\n", .{data});
@@ -632,7 +632,7 @@ pub fn setDataCubemap(
     data: renderite.Shared.SetCubemapData,
     accessor: *renderite.SharedMemoryAccessor,
 ) !void {
-    const data_slice = try accessor.getOrCreate(u8, gpa, data.data) orelse return error.MissingBuffer;
+    const data_slice = try accessor.getOrCreate(u8, data.data) orelse return error.MissingBuffer;
     defer accessor.release(gpa, data_slice);
 
     // std.debug.print("Cubemap upload details: {any}\n", .{data});

--- a/client/Texture.zig
+++ b/client/Texture.zig
@@ -424,7 +424,7 @@ pub fn setData2d(
     accessor: *renderite.SharedMemoryAccessor,
 ) !void {
     const data_slice = try accessor.getOrCreate(u8, gpa, data.data) orelse return error.MissingBuffer;
-    defer data_slice.release(accessor);
+    defer accessor.release(gpa, data_slice);
 
     // std.debug.print("Texture2D upload details: {any}\n", .{data});
 
@@ -554,7 +554,7 @@ pub fn setData3d(
     accessor: *renderite.SharedMemoryAccessor,
 ) !void {
     const data_slice = try accessor.getOrCreate(u8, gpa, data.data) orelse return error.MissingBuffer;
-    defer data_slice.release(accessor);
+    defer accessor.release(gpa, data_slice);
 
     // std.debug.print("Texture3D upload details: {any}\n", .{data});
 
@@ -633,7 +633,7 @@ pub fn setDataCubemap(
     accessor: *renderite.SharedMemoryAccessor,
 ) !void {
     const data_slice = try accessor.getOrCreate(u8, gpa, data.data) orelse return error.MissingBuffer;
-    defer data_slice.release(accessor);
+    defer accessor.release(gpa, data_slice);
 
     // std.debug.print("Cubemap upload details: {any}\n", .{data});
 

--- a/client/graphics.zig
+++ b/client/graphics.zig
@@ -5,20 +5,20 @@ const gpu = @import("gpu");
 const App = @import("App.zig");
 const Assets = @import("Assets.zig");
 const Texture = @import("Texture.zig");
-const pooling = @import("pooling.zig");
+const Pooling = @import("renderite").Pooling;
 
 const log = std.log.scoped(.graphics);
 
-pub const TransferBufferPool = pooling.FrameReferencedResourcePool(
+pub const TransferBufferPool = Pooling.FrameReferencedResourcePool(
     gpu.Device,
-    pooling.SizedKey(gpu.TransferBufferUsage),
+    Pooling.SizedKey(gpu.TransferBufferUsage),
     gpu.TransferBuffer,
     createTransferBuffer,
     releaseTransferBuffer,
     120,
 );
 
-fn createTransferBuffer(device: gpu.Device, key: pooling.SizedKey(gpu.TransferBufferUsage)) !gpu.TransferBuffer {
+fn createTransferBuffer(device: gpu.Device, key: Pooling.SizedKey(gpu.TransferBufferUsage)) !gpu.TransferBuffer {
     var buffer_name_buf: [64]u8 = undefined;
     // SAFETY: it's big enough
     const buffer_name = std.fmt.bufPrintZ(&buffer_name_buf, "Pooled Transfer Buffer (size {d})", .{key.size}) catch unreachable;

--- a/client/render_spaces/RenderSpace.zig
+++ b/client/render_spaces/RenderSpace.zig
@@ -71,7 +71,7 @@ pub fn handleUpdate(self: *RenderSpace, gpa: std.mem.Allocator, accessor: *rende
 
     if (update.reflectionProbeSH2Taks) |sh2_tasks_descriptor| {
         if (try accessor.getOrCreate(renderite.Shared.ReflectionProbeSH2Task, gpa, sh2_tasks_descriptor.tasks)) |sh2_tasks| {
-            defer sh2_tasks.release(accessor);
+            defer accessor.release(gpa, sh2_tasks);
 
             for (sh2_tasks.data) |*task| {
                 task.result = .Failed;

--- a/client/render_spaces/RenderSpace.zig
+++ b/client/render_spaces/RenderSpace.zig
@@ -70,7 +70,7 @@ pub fn handleUpdate(self: *RenderSpace, gpa: std.mem.Allocator, accessor: *rende
     self.properties = loadProperties(update);
 
     if (update.reflectionProbeSH2Taks) |sh2_tasks_descriptor| {
-        if (try accessor.getOrCreate(renderite.Shared.ReflectionProbeSH2Task, gpa, sh2_tasks_descriptor.tasks)) |sh2_tasks| {
+        if (try accessor.getOrCreate(renderite.Shared.ReflectionProbeSH2Task, sh2_tasks_descriptor.tasks)) |sh2_tasks| {
             defer accessor.release(gpa, sh2_tasks);
 
             for (sh2_tasks.data) |*task| {

--- a/client/render_spaces/Transforms.zig
+++ b/client/render_spaces/Transforms.zig
@@ -31,8 +31,7 @@ pub fn handleUpdate(
     update: renderite.Shared.TransformsUpdate,
 ) !void {
     if (try accessor.getOrCreate(i32, gpa, update.removals)) |removals| {
-        defer removals.release(accessor);
-
+        defer accessor.release(gpa, removals);
         for (removals.data) |removal| {
             if (removal < 0) {
                 break;
@@ -69,8 +68,7 @@ pub fn handleUpdate(
     }
 
     if (try accessor.getOrCreate(renderite.Shared.TransformParentUpdate, gpa, update.parentUpdates)) |parent_updates| {
-        defer parent_updates.release(accessor);
-
+        defer accessor.release(gpa, parent_updates);
         for (parent_updates.data) |parent_update| {
             if (parent_update.transformId < 0) {
                 break;
@@ -83,8 +81,7 @@ pub fn handleUpdate(
     }
 
     if (try accessor.getOrCreate(renderite.Shared.TransformPoseUpdate, gpa, update.poseUpdates)) |pose_updates| {
-        defer pose_updates.release(accessor);
-
+        defer accessor.release(gpa, pose_updates);
         for (pose_updates.data) |pose_update| {
             if (pose_update.transformId < 0) {
                 break;

--- a/client/render_spaces/Transforms.zig
+++ b/client/render_spaces/Transforms.zig
@@ -30,8 +30,9 @@ pub fn handleUpdate(
     accessor: *renderite.SharedMemoryAccessor,
     update: renderite.Shared.TransformsUpdate,
 ) !void {
-    if (try accessor.getOrCreate(i32, gpa, update.removals)) |removals| {
+    if (try accessor.getOrCreate(i32, update.removals)) |removals| {
         defer accessor.release(gpa, removals);
+
         for (removals.data) |removal| {
             if (removal < 0) {
                 break;
@@ -67,8 +68,9 @@ pub fn handleUpdate(
         }
     }
 
-    if (try accessor.getOrCreate(renderite.Shared.TransformParentUpdate, gpa, update.parentUpdates)) |parent_updates| {
+    if (try accessor.getOrCreate(renderite.Shared.TransformParentUpdate, update.parentUpdates)) |parent_updates| {
         defer accessor.release(gpa, parent_updates);
+
         for (parent_updates.data) |parent_update| {
             if (parent_update.transformId < 0) {
                 break;
@@ -80,8 +82,9 @@ pub fn handleUpdate(
         }
     }
 
-    if (try accessor.getOrCreate(renderite.Shared.TransformPoseUpdate, gpa, update.poseUpdates)) |pose_updates| {
+    if (try accessor.getOrCreate(renderite.Shared.TransformPoseUpdate, update.poseUpdates)) |pose_updates| {
         defer accessor.release(gpa, pose_updates);
+
         for (pose_updates.data) |pose_update| {
             if (pose_update.transformId < 0) {
                 break;

--- a/client/tests.zig
+++ b/client/tests.zig
@@ -1,5 +1,5 @@
 comptime {
     _ = @import("Texture.zig");
     _ = @import("Mesh.zig");
-    _ = @import("pooling.zig");
+    _ = @import("renderite").Pooling;
 }

--- a/renderite/buffer.zig
+++ b/renderite/buffer.zig
@@ -30,6 +30,10 @@ pub const SharedMemoryBufferDescriptor = extern struct {
             .length = try ipc.readInt(i32),
         };
     }
+
+    pub fn compare(self: SharedMemoryBufferDescriptor, other: SharedMemoryBufferDescriptor) std.math.Order {
+        return if (self.buffer_id == other.buffer_id) .eq else .lt;
+    }
 };
 
 comptime {

--- a/renderite/buffer.zig
+++ b/renderite/buffer.zig
@@ -7,6 +7,8 @@ const serialization = @import("serialization.zig");
 const IpcSerializer = serialization.IpcSerializer;
 const IpcDeserializer = serialization.IpcDeserializer;
 
+const pooling = @import("pooling.zig");
+
 const log = std.log.scoped(.shmem);
 
 pub const SharedMemoryBufferDescriptor = extern struct {
@@ -55,44 +57,18 @@ pub const BufferId = enum(i32) {
 };
 
 pub const SharedMemoryAccessor = struct {
-    const Handle = struct {
-        references: std.atomic.Value(usize),
-        view: MemoryView,
-
-        pub fn deinit(self: Handle) void {
-            // SAFETY: nothing should have a reference on this by the time this is called!
-            std.debug.assert(self.references.raw == 0);
-
-            self.view.deinit();
-        }
-    };
+    const BufferKey = pooling.SimpleKey(SharedMemoryBufferDescriptor);
+    const Pool = pooling.FrameReferencedResourcePool([]const u8, BufferKey, MemoryView, createPoolValue, releasePoolValue, 120);
 
     pub fn Slice(comptime ChildType: type) type {
         return struct {
             buffer: BufferId,
             data: []align(1) ChildType,
-
-            const Self = @This();
-
-            pub fn release(self: Self, accessor: *SharedMemoryAccessor) void {
-                accessor.lock.lock();
-                defer accessor.lock.unlock();
-
-                // SAFETY: buffer should always exist at this point
-                const handle = accessor.handles.getPtr(self.buffer).?;
-
-                const previous_references = handle.references.fetchSub(1, .seq_cst);
-
-                // if the handle used to have 1 reference, and now has zero, we should de-init it.
-                if (previous_references == 1) {
-                    accessor.freeHandleLocked(self.buffer, handle);
-                }
-            }
+            entry: Pool.Entry,
         };
     }
 
-    lock: std.Thread.Mutex,
-    handles: std.AutoHashMapUnmanaged(BufferId, Handle),
+    pool: Pool,
     prefix: []const u8,
 
     pub fn init(gpa: std.mem.Allocator, prefix: []const u8) !SharedMemoryAccessor {
@@ -100,21 +76,16 @@ pub const SharedMemoryAccessor = struct {
         errdefer gpa.free(our_prefix);
 
         return .{
-            .handles = .empty,
             .prefix = our_prefix,
-            .lock = .{},
+            .pool = .init(our_prefix),
         };
     }
 
     pub fn getOrCreate(
         self: *SharedMemoryAccessor,
         comptime ChildType: type,
-        gpa: std.mem.Allocator,
         descriptor: SharedMemoryBufferDescriptor,
     ) !?Slice(ChildType) {
-        self.lock.lock();
-        defer self.lock.unlock();
-
         const buffer_id: BufferId = .from(descriptor.buffer_id);
 
         const offset: usize = @intCast(descriptor.offset);
@@ -123,55 +94,38 @@ pub const SharedMemoryAccessor = struct {
         if (length == 0)
             return null;
 
-        if (self.handles.getPtr(buffer_id)) |handle| {
-            // Increment the references
-            const previous_references = handle.references.fetchAdd(1, .seq_cst);
-            std.debug.assert(previous_references > 0);
-
-            return .{
-                .buffer = buffer_id,
-                .data = @ptrCast(handle.view.data[offset .. offset + length]),
-            };
-        }
-
-        var memory_view_buf: [std.fs.max_path_bytes]u8 = undefined;
-        const memory_view_name = std.fmt.bufPrintZ(&memory_view_buf, "{s}_{X}", .{ self.prefix, descriptor.buffer_id }) catch unreachable;
-
-        log.debug("Initializing shared memory view {s}", .{memory_view_name});
-
-        const view = try MemoryView.init(.{
-            .capacity = @intCast(descriptor.buffer_capacity),
-            .memory_view_name = memory_view_name,
-        });
-
-        const result = try self.handles.getOrPutValue(gpa, buffer_id, .{
-            .view = view,
-            .references = .init(1),
-        });
+        const entry = try self.pool.acquire(.{ .value = descriptor });
 
         return .{
             .buffer = buffer_id,
-            .data = @ptrCast(result.value_ptr.view.data[offset .. offset + length]),
+            .data = @ptrCast(entry.value.data[offset .. offset + length]),
+            .entry = entry,
         };
     }
 
-    fn freeHandleLocked(self: *SharedMemoryAccessor, buffer: BufferId, handle: *Handle) void {
-        handle.deinit();
+    fn createPoolValue(prefix: []const u8, key: BufferKey) !MemoryView {
+        var memory_view_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const memory_view_name = std.fmt.bufPrintZ(&memory_view_buf, "{s}_{X}", .{ prefix, key.value.buffer_id }) catch unreachable;
 
-        const was_present = self.handles.remove(buffer);
-        std.debug.assert(was_present);
+        log.debug("Initializing shared memory view {s}", .{memory_view_name});
 
-        var ctx: std.hash_map.AutoContext(BufferId) = .{};
-        self.handles.rehash(&ctx);
+        return try MemoryView.init(.{
+            .capacity = @intCast(key.value.buffer_capacity),
+            .memory_view_name = memory_view_name,
+        });
+    }
+
+    fn releasePoolValue(prefix: []const u8, view: MemoryView) void {
+        _ = prefix;
+        view.deinit();
+    }
+
+    pub fn release(self: *SharedMemoryAccessor, gpa: std.mem.Allocator, slice: anytype) void {
+        self.pool.release(gpa, slice.entry) catch @panic("OOM while memory view returning to pool");
     }
 
     pub fn deinit(self: *SharedMemoryAccessor, gpa: std.mem.Allocator) void {
-        var iter = self.handles.valueIterator();
-        while (iter.next()) |handle| {
-            handle.deinit();
-        }
-
-        self.handles.deinit(gpa);
+        self.pool.deinit(gpa);
 
         gpa.free(self.prefix);
     }

--- a/renderite/pooling.zig
+++ b/renderite/pooling.zig
@@ -9,6 +9,12 @@ pub fn SimpleKey(comptime Child: type) type {
         const Self = @This();
 
         pub fn compare(self: Self, other: Self) std.math.Order {
+            if (@hasDecl(Child, "compare"))
+                return self.value.compare(other.value);
+
+            if (@hasDecl(Child, "eql"))
+                return if (self.value.eql(other.value)) .eq else .lt;
+
             return if (self.value == other.value) .eq else .lt;
         }
     };

--- a/renderite/root.zig
+++ b/renderite/root.zig
@@ -11,3 +11,4 @@ pub const SharedMemoryBufferDescriptor = buffer.SharedMemoryBufferDescriptor;
 pub const SharedMemoryAccessor = buffer.SharedMemoryAccessor;
 pub const Bootstrap = @import("Bootstrap.zig");
 pub const InitSettings = @import("InitSettings.zig");
+pub const Pooling = @import("pooling.zig");


### PR DESCRIPTION
This makes it so the SharedMemoryAccessor uses the new frame-based pooling system that was made generalized in #76. The pre-existing reference-counted handles have been replaced with a pool based on the backing `MemoryView`s.

I'm not sure about the exact performance gains, but it does completely stop memory views from being created every frame - only about a couple get created and then they're reused.