### PR TITLE
logging: Move noisy log calls to a build option

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -18,6 +18,7 @@ const Options = struct {
     xr_backend: XrBackend,
 
     safety: bool,
+    noisy_logging: bool,
 
     tracy: struct {
         enable: bool,
@@ -82,6 +83,7 @@ pub fn build(b: *std.Build) !void {
         },
 
         .safety = optimize == .ReleaseSafe or optimize == .Debug,
+        .noisy_logging = b.option(bool, "noisy_logging", "Enable noisy logging in debug builds") orelse false,
 
         .tracy = .{
             .enable = enable_tracy,
@@ -422,6 +424,7 @@ pub fn build(b: *std.Build) !void {
                 .{ .name = "zinterprocess", .module = zinterprocess_mod },
                 .{ .name = "tracy", .module = tracy_mod },
                 .{ .name = "math", .module = math_mod },
+                .{ .name = "options", .module = options_module },
             },
         });
 

--- a/client/App.zig
+++ b/client/App.zig
@@ -659,7 +659,7 @@ fn handleMessages(self: *App, frame_context: *graphics.FrameContext) !void {
 }
 
 fn messagingCallback(self: *App, queue_type: MessagingHost.QueueManager.Type, message: renderite.ParsedCommand) void {
-    log.debug("Got message {s} on queue {s}", .{ @tagName(message.command), @tagName(queue_type) });
+    if (build_options.noisy_logging) log.debug("Got message {s} on queue {s}", .{ @tagName(message.command), @tagName(queue_type) });
 
     switch (queue_type) {
         // messages coming in the primary queue need to be processed ASAP by the main thread
@@ -785,7 +785,7 @@ fn engineHandleMessage(self: *App, message: renderite.ParsedCommand) !void {
     }
 
     self.game.last_frame_index = frame_submit_data.frameIndex;
-    log.debug("Frame {d} completion", .{frame_submit_data.frameIndex});
+    if (build_options.noisy_logging) log.debug("Frame {d} completion", .{frame_submit_data.frameIndex});
 
     try self.updateRenderSpaces(frame_submit_data.renderSpaces);
 
@@ -1072,7 +1072,7 @@ pub fn frameLoop(self: *App) !void {
                     },
                 }, std.time.ns_per_s);
 
-                log.debug("Sent frame {d} start", .{self.game.last_frame_index + 1});
+                if (build_options.noisy_logging) log.debug("Sent frame {d} start", .{self.game.last_frame_index + 1});
 
                 self.game.engine_thread_ready_for_begin_frame.reset();
             }

--- a/client/Assets.zig
+++ b/client/Assets.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 
 const gpu = @import("gpu");
 const renderite = @import("renderite");
+const build_options = @import("options").build_options;
 
 const graphics = @import("graphics.zig");
 const Mesh = @import("Mesh.zig");
@@ -299,7 +300,7 @@ pub fn uploadMeshData(self: *Assets, gpa: std.mem.Allocator, frame_context: *gra
     const mesh = result.value_ptr;
     if (result.found_existing) {
         try mesh.setData(gpa, frame_context, accessor, mesh_upload_data);
-        log.debug("Updated mesh {d}", .{mesh_upload_data.assetId});
+        if (build_options.noisy_logging) log.debug("Updated mesh {d}", .{mesh_upload_data.assetId});
     } else {
         mesh.* = try .init(gpa, frame_context, accessor, mesh_upload_data);
         log.debug("Created mesh {d}", .{mesh_upload_data.assetId});

--- a/client/pooling.zig
+++ b/client/pooling.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
 
+const build_options = @import("options").build_options;
+
 const log = std.log.scoped(.pooling);
 
 pub fn SimpleKey(comptime Child: type) type {
@@ -121,7 +123,7 @@ pub fn FrameReferencedResourcePool(comptime Context: type, comptime Key: type, c
 
             entry_to_append.frames_since_usage = 0;
             try self.entries.append(gpa, entry_to_append);
-            log.debug("Released entry {s} back into pool", .{@typeName(Value)});
+            if (build_options.noisy_logging) log.debug("Released entry {s} back into pool", .{@typeName(Value)});
         }
 
         pub fn frameTick(self: *Self) void {

--- a/renderite/buffer.zig
+++ b/renderite/buffer.zig
@@ -133,8 +133,6 @@ pub const SharedMemoryAccessor = struct {
         var memory_view_buf: [std.fs.max_path_bytes]u8 = undefined;
         const memory_view_name = std.fmt.bufPrintZ(&memory_view_buf, "{s}_{X}", .{ self.prefix, descriptor.buffer_id }) catch unreachable;
 
-        log.debug("Initializing shared memory view {s}", .{memory_view_name});
-
         const view = try MemoryView.init(.{
             .capacity = @intCast(descriptor.buffer_capacity),
             .memory_view_name = memory_view_name,

--- a/renderite/messaging.zig
+++ b/renderite/messaging.zig
@@ -3,6 +3,7 @@ const builtin = @import("builtin");
 
 const tracy = @import("tracy");
 const zinterprocess = @import("zinterprocess");
+const build_options = @import("options").build_options;
 
 const InitSettings = @import("InitSettings.zig");
 const serialization = @import("serialization.zig");
@@ -220,7 +221,7 @@ pub fn MessagingHost(comptime Context: type) type {
 
                 const serializer = IpcSerializer.init(&writer);
 
-                log.debug("Sending message {s}", .{@tagName(command)});
+                if (build_options.noisy_logging) log.debug("Sending message {s}", .{@tagName(command)});
                 try serializer.writePolymorphic(shared.RendererCommand, command);
 
                 try self.publisher.enqueue(data[0..writer.end]);


### PR DESCRIPTION
This solves a frustrating issue where there's lots of logging every frame. I'm trying to debug stuff with mouse input and I can't see the logs I'm printing because there's 10 lines of garbage being produced each frame, and it gets kicked out of my scrollback near instantly.

To fix this I've introduced a new build option, `noisy_logging`, making the log output in a fully loaded cloud home near-zero. I went with a build option because this kind of trace-logging can still be helpful. It will still log a bunch while loading stuff but that's fine.