### PR TITLE
docs: Add renderer manifest v1

### DIFF
--- a/client/Gloobie.renderer.json
+++ b/client/Gloobie.renderer.json
@@ -1,0 +1,7 @@
+{
+    "version": 1,
+    "name": "Gloobie",
+    "winExecutablePath": "Renderers/Gloobie/Gloobie.exe",
+    "unixExecutablePath": "Renderers/Gloobie/Renderite.Gloobie",
+    "runInWine": false
+}

--- a/docs/renderer-manifest.md
+++ b/docs/renderer-manifest.md
@@ -45,10 +45,10 @@ The word `optional` below means that the field MAY be excluded or left as `null`
 `string` `name`: A user-friendly name of the renderer. This can be any text, but MUST NOT be over 64 bytes.
 Example: `Gloobie`
 
-`string` `winExecutablePath`: The path to the renderer to run on Windows. This MUST be relative to the Installation Directory.
+`string` `winExecutablePath`: The path to the renderer to run on Windows. This SHOULD be relative to the Installation Directory, but MAY be a full path for the purposes of development.
 Example: `Renderers/Gloobie/Gloobie.exe`
 
-`string` `unixExecutablePath`: The path to the renderer to run on Linux/Mac/other unix-like platforms. This MUST be relative to the Installation Directory.
+`string` `unixExecutablePath`: The path to the renderer to run on Linux/Mac/other unix-like platforms. This SHOULD be relative to the Installation Directory, but MAY be a full path for the purposes of development.
 Example: `Renderers/Gloobie/Renderite.Gloobie`
 
 `optional` `bool` `runInWine`: When true on unix-like platforms, the Renderer should be executed under a Wine context. Default: `false`

--- a/docs/renderer-manifest.md
+++ b/docs/renderer-manifest.md
@@ -2,9 +2,9 @@
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", and "MAY" in this documentation are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
 
-The renderer manifest file describes a custom renderer compatible with FrooxEngine. It includes the name and details required for a bootstrapper to run the renderer.
+The Renderer Manifest File describes a custom Renderer compatible with FrooxEngine. It includes the name and details required for a Bootstrapper to run the Renderer.
 
-This also covers how bootstrappers should implement things when reading them.
+This also covers how Bootstrappers should implement things when reading them.
 
 ## Glossary
 
@@ -20,39 +20,43 @@ This also covers how bootstrappers should implement things when reading them.
 
 ## Location, format, and naming
 
-The renderer manifest file is a JSON file with the extension of ".renderer.json". It MUST placed in a folder under Resonite's installation directory named "Renderers".
-As an example, Gloobie's manifest is stored as "Renderers/Gloobie.renderer.json".
+The Renderer Manifest File MUST reside in the Renderers subdirectory of the Installation Directory.
+As an example, Gloobie's manifest is stored as "Renderers/Gloobie.Renderer.json".
 
 This file and the contents within MUST be encoded as either UTF-8 or WTF-8, with no Byte Order Mark (BOM).
 
 ## Versioning
 
-`version` refers to the schema version of the manifest file.
+`int` `version` refers to the schema version of the manifest file.
 `version` MUST be present, MUST be an integer, and MUST be the first field in the file.
 
 ## Compatibility between versions
 
-Bootstrappers MUST be backwards and forwards compatible with every version of this specification. In other words, the bootstrapper MUST still try to launch the renderer using the data it has available, even if the manifest version is not equal to the implemented version.
+Bootstrappers MUST be backwards and forwards compatible with every version of this specification. In other words, the Bootstrapper MUST still try to launch the Renderer using the data it has available, even if the manifest version is not equal to the implemented version.
 
-For example, if a bootstrapper is targeting Version 2, and comes across a manifest of Version 1, it MUST NOT fail due to a missing field.
+For example, if a Bootstrapper is targeting Version 2, and comes across a manifest of Version 1, it MUST NOT fail due to a missing field.
 
-The bootstrapper MAY warn the user if the manifest version is higher than expected. For example, if the bootstrapper implements Version 1, but sees an unknown field or a manifest of Version 2, the bootstrapper could warn the user to update their bootstrapper before launching that renderer.
+The Bootstrapper MAY warn the user if the manifest version is higher than expected. For example, if the Bootstrapper implements Version 1, but sees an unknown field or a manifest of Version 2, the Bootstrapper could warn the user to update their Bootstrapper before launching that Renderer.
 
 ## Fields
 
-The word `optional` below means that the field MAY be excluded or left as `null`. A RECOMMENDED fallback path is provided for these fields.
+The word `optional` below means that the field MAY be excluded or left as `null`. A RECOMMENDED fallback path is provided for these fields when this is the case.
+
+This does not mean `optional` fields may be entirely unhandled by the Bootstrapper - Bootstrappers MUST implement support for `optional` fields in the case that they are present.
+
+Fields not marked `optional` MUST be present and valid.
 
 ## Version 1
 
 ### `string` `name`
 
-A user-friendly name of the renderer. This can be any text, but MUST NOT be over 64 bytes.
+A user-friendly name of the Renderer. This can be any text, but MUST NOT be over 64 bytes.
 
 Example: `"Gloobie"`
 
 ### `string` `winExecutablePath`
 
-The path to the renderer to run on Windows.
+The path to the Renderer to run on Windows.
 
 This SHOULD be relative to the Installation Directory, but MAY be a full path for the purposes of development.
 
@@ -62,16 +66,20 @@ Example: `"Renderers/Gloobie/Gloobie.exe"`
 
 ### `string` `unixExecutablePath`
 
-The path to the renderer to run on Linux/Mac/other unix-like platforms.
+The path to the Renderer to run on Linux, MacOS, and other unix-like platforms.
 
 This SHOULD be relative to the Installation Directory, but MAY be a full path for the purposes of development.
 
-This path MUST be a valid UTF-8/WTF-8 sequence, and the length when represented as bytes MUST not exceed the maximum path length on Linux.
+This path MUST be a valid UTF-8, and the length when represented as bytes MUST not exceed the maximum path length on Linux.
+
+This MAY be an empty string, however this is only the case when `runInWine` is set to `true`. In the case that both are set, this field MUST be ignored in favor of `winExecutablePath`.
 
 Example: `"Renderers/Gloobie/Renderite.Gloobie"`
 
 ### `optional` `bool` `runInWine`
 
-When true on unix-like platforms, the Renderer should be executed under a Wine context. 
+When `true` on unix-like platforms, the Renderer should be executed under a Wine context using the `winExecutablePath`.
+
+This should generally be unnecessary, excluding the default renderer.
 
 Default: `false`

--- a/docs/renderer-manifest.md
+++ b/docs/renderer-manifest.md
@@ -20,8 +20,8 @@ This also covers how Bootstrappers should implement things when reading them.
 
 ## Location, format, and naming
 
-The Renderer Manifest File MUST reside in the Renderers subdirectory of the Installation Directory.
-As an example, Gloobie's manifest is stored as "Renderers/Gloobie.Renderer.json".
+The Renderer Manifest File MUST reside in the "Renderers" subdirectory of the Installation Directory with an extension of `.renderer.json`.
+As an example, Gloobie's manifest is stored as "Renderers/Gloobie.renderer.json".
 
 This file and the contents within MUST be encoded as either UTF-8 or WTF-8, with no Byte Order Mark (BOM).
 

--- a/docs/renderer-manifest.md
+++ b/docs/renderer-manifest.md
@@ -18,10 +18,12 @@ This also covers how bootstrappers should implement things when reading them.
 
 "Bootstrapper" refers to a program that starts both FrooxEngine and a Renderer.
 
-## Location and naming
+## Location, format, and naming
 
 The renderer manifest file is a JSON file with the extension of ".renderer.json". It MUST placed in a folder under Resonite's installation directory named "Renderers".
 As an example, Gloobie's manifest is stored as "Renderers/Gloobie.renderer.json".
+
+This file and the contents within MUST be encoded as either UTF-8 or WTF-8, with no Byte Order Mark (BOM).
 
 ## Versioning
 
@@ -40,15 +42,36 @@ The bootstrapper MAY warn the user if the manifest version is higher than expect
 
 The word `optional` below means that the field MAY be excluded or left as `null`. A RECOMMENDED fallback path is provided for these fields.
 
-### Version 1
+## Version 1
 
-`string` `name`: A user-friendly name of the renderer. This can be any text, but MUST NOT be over 64 bytes.
-Example: `Gloobie`
+### `string` `name`
 
-`string` `winExecutablePath`: The path to the renderer to run on Windows. This SHOULD be relative to the Installation Directory, but MAY be a full path for the purposes of development.
-Example: `Renderers/Gloobie/Gloobie.exe`
+A user-friendly name of the renderer. This can be any text, but MUST NOT be over 64 bytes.
 
-`string` `unixExecutablePath`: The path to the renderer to run on Linux/Mac/other unix-like platforms. This SHOULD be relative to the Installation Directory, but MAY be a full path for the purposes of development.
-Example: `Renderers/Gloobie/Renderite.Gloobie`
+Example: `"Gloobie"`
 
-`optional` `bool` `runInWine`: When true on unix-like platforms, the Renderer should be executed under a Wine context. Default: `false`
+### `string` `winExecutablePath`
+
+The path to the renderer to run on Windows.
+
+This SHOULD be relative to the Installation Directory, but MAY be a full path for the purposes of development.
+
+This path MUST be a valid UTF-8/WTF-8 sequence that when represented as WTF-16 does not exceed the maximum path length on Windows.
+
+Example: `"Renderers/Gloobie/Gloobie.exe"`
+
+### `string` `unixExecutablePath`
+
+The path to the renderer to run on Linux/Mac/other unix-like platforms.
+
+This SHOULD be relative to the Installation Directory, but MAY be a full path for the purposes of development.
+
+This path MUST be a valid UTF-8/WTF-8 sequence, and the length when represented as bytes MUST not exceed the maximum path length on Linux.
+
+Example: `"Renderers/Gloobie/Renderite.Gloobie"`
+
+### `optional` `bool` `runInWine`
+
+When true on unix-like platforms, the Renderer should be executed under a Wine context. 
+
+Default: `false`

--- a/docs/renderer-manifest.md
+++ b/docs/renderer-manifest.md
@@ -1,0 +1,54 @@
+# Renderer Manifest File Specification, Version 1
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", and "MAY" in this documentation are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+
+The renderer manifest file describes a custom renderer compatible with FrooxEngine. It includes the name and details required for a bootstrapper to run the renderer.
+
+This also covers how bootstrappers should implement things when reading them.
+
+## Glossary
+
+"FrooxEngine" refers to the engine Resonite runs under.
+
+"Installation Directory" refers to the place at which the FrooxEngine game is installed to - usually the same folder as `FrooxEngine.dll` and `Renderite.Shared.dll`.
+
+"Wine" refers to the Windows compatibility layer on unix-like platforms. It can also mean Proton, the fork shipped with Steam.
+
+"Renderer" refers to a program implementing FrooxEngine's IPC bindings, usually using the GPU to draw the scene for the user.
+
+"Bootstrapper" refers to a program that starts both FrooxEngine and a Renderer.
+
+## Location and naming
+
+The renderer manifest file is a JSON file with the extension of ".renderer.json". It MUST placed in a folder under Resonite's installation directory named "Renderers".
+As an example, Gloobie's manifest is stored as "Renderers/Gloobie.renderer.json".
+
+## Versioning
+
+`version` refers to the schema version of the manifest file.
+`version` MUST be present, MUST be an integer, and MUST be the first field in the file.
+
+## Compatibility between versions
+
+Bootstrappers MUST be backwards and forwards compatible with every version of this specification. In other words, the bootstrapper MUST still try to launch the renderer using the data it has available, even if the manifest version is not equal to the implemented version.
+
+For example, if a bootstrapper is targeting Version 2, and comes across a manifest of Version 1, it MUST NOT fail due to a missing field.
+
+The bootstrapper MAY warn the user if the manifest version is higher than expected. For example, if the bootstrapper implements Version 1, but sees an unknown field or a manifest of Version 2, the bootstrapper could warn the user to update their bootstrapper before launching that renderer.
+
+## Fields
+
+The word `optional` below means that the field MAY be excluded or left as `null`. A RECOMMENDED fallback path is provided for these fields.
+
+### Version 1
+
+`string` `name`: A user-friendly name of the renderer. This can be any text, but MUST NOT be over 64 bytes.
+Example: `Gloobie`
+
+`string` `winExecutablePath`: The path to the renderer to run on Windows. This MUST be relative to the Installation Directory.
+Example: `Renderers/Gloobie/Gloobie.exe`
+
+`string` `unixExecutablePath`: The path to the renderer to run on Linux/Mac/other unix-like platforms. This MUST be relative to the Installation Directory.
+Example: `Renderers/Gloobie/Renderite.Gloobie`
+
+`optional` `bool` `runInWine`: When true on unix-like platforms, the Renderer should be executed under a Wine context. Default: `false`


### PR DESCRIPTION
RFC.

This is a spec that defines how bootstrappers should discover custom renderers and how to execute them.